### PR TITLE
Edge Delta Cron job on the API versions reordering

### DIFF
--- a/edgedelta/templates/agent_updater.yaml
+++ b/edgedelta/templates/agent_updater.yaml
@@ -29,10 +29,10 @@ roleRef:
   name: agent-updater-roles
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- if .Capabilities.APIVersions.Has "batch/v1beta1" }}
-apiVersion: batch/v1beta1
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "batch/v1" }}
 apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:


### PR DESCRIPTION
Why do we need this change?
- This commit is about cron-Job api-version reverse the if..else condition where our cluster supports backward compatibility.
- This is below error we are getting in our clusters
**Resource not found in cluster: batch/v1beta1/CronJob:edgedelta-updater**
- If we reverse if..else condition then it’s supports in our cluster and edgedelta chart fully deployed into clusters