### PR TITLE
make cluster-level resources optional

### DIFF
--- a/charts/edgedelta-gateway/README.md
+++ b/charts/edgedelta-gateway/README.md
@@ -140,6 +140,8 @@ Edge Delta Gateway Agent Chart for Kubernetes
 | profilerPort | string | `""` |  |
 | promPort | string | `""` |  |
 | repository | string | `"gcr.io/edgedelta"` |  |
+| rbac.namespaced.rules | list | `[]` | Rules for the namespace-scoped Role. |
+| rbac.scope | string | `"cluster"` | RBAC scope. Supported values are cluster and namespace. |
 | resources.limits.cpu | string | `"2000m"` |  |
 | resources.limits.memory | string | `"2Gi"` |  |
 | resources.requests.cpu | string | `"200m"` |  |

--- a/charts/edgedelta-gateway/templates/service_account.yaml
+++ b/charts/edgedelta-gateway/templates/service_account.yaml
@@ -1,3 +1,42 @@
+{{- if and (ne .Values.rbac.scope "cluster") (ne .Values.rbac.scope "namespace") }}
+{{- fail "rbac.scope must be either cluster or namespace" }}
+{{- end }}
+{{- if eq .Values.rbac.scope "namespace" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "edgedelta.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "edgedelta.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "edgedelta.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "edgedelta.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "edgedelta.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "edgedelta.labels" . | nindent 4 }}
+rules:
+{{- range .Values.rbac.namespaced.rules }}
+- apiGroups: {{ .apiGroups | toJson }}
+  resources: {{ .resources | toJson }}
+  {{- with .resourceNames }}
+  resourceNames: {{ . | toJson }}
+  {{- end }}
+  verbs: {{ .verbs | toJson }}
+{{- end }}
+---
+{{- end }}
+{{- if eq .Values.rbac.scope "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -42,6 +81,7 @@ rules:
   verbs: ["get"]
 {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/edgedelta-gateway/values.yaml
+++ b/charts/edgedelta-gateway/values.yaml
@@ -34,6 +34,13 @@ goMemLimit: ""
 
 edEnableControllerDiscovery: true
 
+rbac:
+  # rbac.scope -- RBAC scope. Supported values are cluster and namespace.
+  scope: cluster
+  namespaced:
+    # rbac.namespaced.rules -- Rules for the namespace-scoped Role.
+    rules: []
+
 # ClusterRole rules configuration
 # These rules define the RBAC permissions for the EdgeDelta gateway
 # You can customize these rules to match your cluster's security requirements


### PR DESCRIPTION
Adds an `rbac.scope` value to the `edgedelta-gateway` chart so users can deploy with only namespace-level access instead of cluster-wide.

The default is `cluster`, so existing installs keep the current behavior unless they explicitly set:

```yaml
rbac:
  scope: namespace